### PR TITLE
add soft deletion of script functionality

### DIFF
--- a/docs/openapi3.yaml
+++ b/docs/openapi3.yaml
@@ -52,6 +52,7 @@ paths:
         - $ref: '#/components/parameters/QueryPaginationPage'
         - $ref: '#/components/parameters/QueryPaginationSize'
         - $ref: '#/components/parameters/QueryScriptsSort'
+        - $ref: '#/components/parameters/QueryScriptsShowInactive'
       responses:
         '200':
           description: Expected response to a valid request
@@ -144,6 +145,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ScriptDto'
+        '401':
+          $ref: '#/components/responses/TokenResponse'
+        '403':
+          $ref: '#/paths/~1scripts/get/responses/403'
+  /scripts/restore:
+    post:
+      summary: Restore an inactive script
+      tags:
+        - scripts
+      operationId: scriptsRestore
+      security:
+        - bearerAuth:
+            - SCRIPT_WRITE
+      requestBody:
+        description: The details identifying the inactive script to be restored
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScriptRestoreDto'
+      responses:
+        '200':
+          description: Implementation details of the restored script version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScriptDto'
+        '400':
+          description: inactive script version cannot be restored as there is still another active version
         '401':
           $ref: '#/components/responses/TokenResponse'
         '403':
@@ -1739,6 +1769,17 @@ components:
       description: |
         See https://stackoverflow.com/questions/33018127/spring-data-rest-sort-by-multiple-properties for query parameter formatting. Sort the result set according to the provided keywords. The order of sorting follows the order of the list. By default sorting is applied in the ascending direction but this can be altered by explicitly providing the sorting direction:
          * `name[,desc|,asc]` - Sort by script name.
+    QueryScriptsShowInactive:
+      in: query
+      name: show_inactive
+      required: false
+      schema:
+        type: string
+        enum:
+          - true
+          - false
+        default: false
+      description: 'When set to true, both active and inactive script implementations are retrieved. When set to false, only active script implementations are retrieved'
     PathComponentName:
       name: name
       description: name of the component
@@ -1894,6 +1935,8 @@ components:
           type: string
         description:
           type: string
+        deletedAt:
+          type: string
         version:
           $ref: '#/components/schemas/ScriptVersionDto'
         parameters:
@@ -2018,6 +2061,16 @@ components:
           $ref: '#/components/schemas/PageLinks'
         page:
           $ref: '#/components/schemas/PaginationProperties'
+    ScriptRestoreDto:
+      type: object
+      properties:
+        name:
+          type: string
+        deletedAt:
+          type: string
+        version:
+          type: integer
+          format: int64
     ComponentDto:
       type: object
       properties:

--- a/src/parameters/_index.yaml
+++ b/src/parameters/_index.yaml
@@ -19,6 +19,9 @@ QueryScriptsLabel:
 QueryScriptsSort:
   $ref: './query/scripts/Sort.yaml'
 
+QueryScriptsShowInactive:
+  $ref: './query/scripts/ShowInactive.yaml'
+
 # Components
 ## Path
 PathComponentName:

--- a/src/parameters/query/scripts/ShowInactive.yaml
+++ b/src/parameters/query/scripts/ShowInactive.yaml
@@ -1,0 +1,10 @@
+in: query
+name: show_inactive
+required: false
+schema:
+  type: string
+  enum:
+    - true
+    - false
+  default: false
+description: "When set to true, both active and inactive script implementations are retrieved. When set to false, only active script implementations are retrieved"

--- a/src/paths/_index.yaml
+++ b/src/paths/_index.yaml
@@ -6,6 +6,9 @@
     $ref: "./scripts/create.yaml"
   put:
     $ref: "./scripts/updateAll.yaml"
+'/scripts/restore':
+  post:
+    $ref: "./scripts/restore.yaml"
 
 '/scripts/{name}':
   get:

--- a/src/paths/scripts/fetchAll.yaml
+++ b/src/paths/scripts/fetchAll.yaml
@@ -11,6 +11,7 @@ parameters:
   - $ref: "../../parameters/query/pagination/Page.yaml"
   - $ref: "../../parameters/query/pagination/Size.yaml"
   - $ref: "../../parameters/query/scripts/Sort.yaml"
+  - $ref: "../../parameters/query/scripts/ShowInactive.yaml"
 responses:
   '200':
     description: Expected response to a valid request

--- a/src/paths/scripts/restore.yaml
+++ b/src/paths/scripts/restore.yaml
@@ -1,0 +1,26 @@
+summary: Restore an inactive script
+tags:
+  - scripts
+operationId: scriptsRestore
+security:
+  - bearerAuth: ["SCRIPT_WRITE"]
+requestBody:
+  description: The details identifying the inactive script to be restored
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: "../../schemas/scripts/ScriptRestoreDto.yaml"
+responses:
+  '200':
+    description: Implementation details of the restored script version
+    content:
+      application/json:
+        schema:
+          $ref: "../../schemas/scripts/ScriptDto.yaml"
+  '400':
+    description: inactive script version cannot be restored as there is still another active version
+  "401":
+    $ref: "../../responses/TokenResponse.yaml"
+  "403":
+    $ref: "../../responses/scripts/ResponseScriptForbidden.yaml"

--- a/src/schemas/_index.yaml
+++ b/src/schemas/_index.yaml
@@ -13,6 +13,8 @@ ActionParameterDto:
   $ref: "./scripts/ActionParameterDto.yaml"
 PagedScriptDto:
   $ref: "./scripts/PagedScriptDto.yaml"
+ScriptRestoreDto:
+  $ref: "./scripts/ScriptRestoreDto.yaml"
 
 # Components
 ComponentDto:

--- a/src/schemas/scripts/ScriptDto.yaml
+++ b/src/schemas/scripts/ScriptDto.yaml
@@ -6,6 +6,8 @@ properties:
     type: string
   description:
     type: string
+  deletedAt:
+    type: string
   version:
     $ref: '../../schemas/scripts/ScriptVersionDto.yaml'
   parameters:

--- a/src/schemas/scripts/ScriptRestoreDto.yaml
+++ b/src/schemas/scripts/ScriptRestoreDto.yaml
@@ -1,0 +1,9 @@
+type: object
+properties:
+  name:
+    type: string
+  deletedAt:
+    type: string
+  version:
+    type: integer
+    format: int64


### PR DESCRIPTION
**Description**
Allow the end user:
* to retrieve the inactive scripts by calling GET /scripts with the query_parameter 'show_inactive' to true
* to restore an inactive script by calling POST/scripts/restore with the body containing the necessary details:
  * script name
  * script version
  * script deleted at timestamp 