### PR TITLE
New query Parameter to GET execution-request

### DIFF
--- a/docs/openapi3.yaml
+++ b/docs/openapi3.yaml
@@ -52,7 +52,7 @@ paths:
         - $ref: '#/components/parameters/QueryPaginationPage'
         - $ref: '#/components/parameters/QueryPaginationSize'
         - $ref: '#/components/parameters/QueryScriptsSort'
-        - $ref: '#/components/parameters/QueryScriptIncludeInactive'
+        - $ref: '#/components/parameters/QueryScriptIncludeInActive'
       responses:
         '200':
           description: Expected response to a valid request
@@ -948,6 +948,7 @@ paths:
         - $ref: '#/components/parameters/QueryExecutionRequestVersion'
         - $ref: '#/components/parameters/QueryExecutionRequestLabel'
         - $ref: '#/components/parameters/QueryExecutionRequestEnvironment'
+        - $ref: '#/components/parameters/QueryExecutionRequestRunId'
       responses:
         '200':
           description: Expected response to a valid request
@@ -1740,7 +1741,7 @@ components:
       description: |
         See https://stackoverflow.com/questions/33018127/spring-data-rest-sort-by-multiple-properties for query parameter formatting. Sort the result set according to the provided keywords. The order of sorting follows the order of the list. By default sorting is applied in the ascending direction but this can be altered by explicitly providing the sorting direction:
          * `name[,desc|,asc]` - Sort by script name.
-    QueryScriptIncludeInactive:
+    QueryScriptIncludeInActive:
       in: query
       name: includeInactive
       required: false
@@ -1807,6 +1808,12 @@ components:
     QueryExecutionRequestVersion:
       in: query
       name: version
+      required: false
+      schema:
+        type: string
+    QueryExecutionRequestRunId:
+      in: query
+      name: run-id
       required: false
       schema:
         type: string

--- a/src/parameters/_index.yaml
+++ b/src/parameters/_index.yaml
@@ -53,6 +53,8 @@ QueryExecutionRequestScript:
   $ref: "./query/executionRequests/Script.yaml"
 QueryExecutionRequestVersion:
   $ref: "./query/executionRequests/Version.yaml"
+QueryExecutionRequestRunId:
+  $ref: "./query/executionRequests/RunId.yaml"
 
 # Script Executions
 PathScriptExecutionProcessId:

--- a/src/parameters/query/executionRequests/RunId.yaml
+++ b/src/parameters/query/executionRequests/RunId.yaml
@@ -1,0 +1,5 @@
+in: query
+name: run-id
+required: false
+schema:
+  type: string

--- a/src/paths/executionRequests/fetchAll.yaml
+++ b/src/paths/executionRequests/fetchAll.yaml
@@ -9,6 +9,7 @@ parameters:
   - $ref: "../../parameters/query/executionRequests/Version.yaml"
   - $ref: "../../parameters/query/executionRequests/Label.yaml"
   - $ref: "../../parameters/query/executionRequests/Environment.yaml"
+  - $ref: "../../parameters/query/executionRequests/RunId.yaml"
 responses:
   '200':
     description: Expected response to a valid request


### PR DESCRIPTION
An additional query parameter should be added to the GET /api/execution-requests endpoint:

name: run-id
value: free text